### PR TITLE
Overhaul scoring system

### DIFF
--- a/Assets/Resources/UI/Settings.prefab
+++ b/Assets/Resources/UI/Settings.prefab
@@ -872,7 +872,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -235, y: 3.95}
+  m_AnchoredPosition: {x: -415, y: 3.95}
   m_SizeDelta: {x: 56.3524, y: 38.537}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7980134082313460319
@@ -1375,7 +1375,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -355, y: 3.95}
+  m_AnchoredPosition: {x: -474, y: 3.95}
   m_SizeDelta: {x: 56.3524, y: 38.537}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5792248048066780377
@@ -1644,7 +1644,7 @@ PrefabInstance:
       objectReference: {fileID: 21300000, guid: 8be477a9f3e849741a6a0733e34fb2b1, type: 3}
     - target: {fileID: 2263116013168410575, guid: 6ba87b6ba1590054bba8bb412efbf813, type: 3}
       propertyPath: m_FillAmount
-      value: 0.3
+      value: 0.15
       objectReference: {fileID: 0}
     - target: {fileID: 4255133087051022652, guid: 6ba87b6ba1590054bba8bb412efbf813, type: 3}
       propertyPath: m_Pivot.x
@@ -1796,7 +1796,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2263116013168410575, guid: 6ba87b6ba1590054bba8bb412efbf813, type: 3}
       propertyPath: m_FillAmount
-      value: 0.2
+      value: 0.1
       objectReference: {fileID: 0}
     - target: {fileID: 4255133087051022652, guid: 6ba87b6ba1590054bba8bb412efbf813, type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/Scenes/Singleplayer/Crib.unity
+++ b/Assets/Scenes/Singleplayer/Crib.unity
@@ -2378,7 +2378,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6447396637733666671, guid: 8377530ce8fc76144bbfb61b240f0344, type: 3}
       propertyPath: m_text
-      value: +10 EOCS
+      value: +100 EOCS
       objectReference: {fileID: 0}
     - target: {fileID: 6447396637733666671, guid: 8377530ce8fc76144bbfb61b240f0344, type: 3}
       propertyPath: m_fontSize
@@ -9447,7 +9447,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6447396637733666671, guid: 8377530ce8fc76144bbfb61b240f0344, type: 3}
       propertyPath: m_text
-      value: +10 HOC
+      value: +100 HOC
       objectReference: {fileID: 0}
     - target: {fileID: 6447396637733666671, guid: 8377530ce8fc76144bbfb61b240f0344, type: 3}
       propertyPath: m_fontSize
@@ -20737,7 +20737,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6447396637733666671, guid: 8377530ce8fc76144bbfb61b240f0344, type: 3}
       propertyPath: m_text
-      value: +10 ITP
+      value: +100 ITP
       objectReference: {fileID: 0}
     - target: {fileID: 6447396637733666671, guid: 8377530ce8fc76144bbfb61b240f0344, type: 3}
       propertyPath: m_fontSize
@@ -32506,7 +32506,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6447396637733666671, guid: 8377530ce8fc76144bbfb61b240f0344, type: 3}
       propertyPath: m_text
-      value: +10 NS
+      value: +100 NS
       objectReference: {fileID: 0}
     - target: {fileID: 6447396637733666671, guid: 8377530ce8fc76144bbfb61b240f0344, type: 3}
       propertyPath: m_fontSize

--- a/Assets/Scripts/Classes/Player.cs
+++ b/Assets/Scripts/Classes/Player.cs
@@ -154,7 +154,7 @@ public class Profile
     public Profile(int avatar, string name, string username, int age, string gender, string playerId)
     {
         if (playerId != null) this.playerId = playerId;
-        else playerId = Guid.NewGuid().ToString();
+        else this.playerId = Guid.NewGuid().ToString();
         this.avatar = avatar;
         this.name = name;
         this.username = username;

--- a/Assets/Scripts/Classes/Player.cs
+++ b/Assets/Scripts/Classes/Player.cs
@@ -24,9 +24,9 @@ public class Player
 
     public event Action<string> OnStatUnlocked;
 
-    public Player(int avatar, string name, string username, int age, string gender)
+    public Player(int avatar, string name, string username, int age, string gender, string playerId = null)
     {
-        profile = new(avatar, name, username, age, gender);
+        profile = new(avatar, name, username, age, gender, playerId);
         stats = new Stats();
         activities = new();
     }
@@ -117,7 +117,7 @@ public class Player
 
     public void CheckAndUnlockStats()
     {
-        if (stats.computerHistory >= 0.2f)
+        if (stats.computerHistory >= 100f)
         {
             if (!stats.isNumberSystemUnlocked)
             {
@@ -127,7 +127,7 @@ public class Player
             }
         }
 
-        if (stats.computerElements >= 0.3f)
+        if (stats.computerElements >= 150f)
         {
             if (!stats.isIntroProgrammingUnlocked)
             {
@@ -151,9 +151,10 @@ public class Profile
     public int age;
     public string gender;
 
-    public Profile(int avatar, string name, string username, int age, string gender)
+    public Profile(int avatar, string name, string username, int age, string gender, string playerId)
     {
-        playerId = Guid.NewGuid().ToString();
+        if (playerId != null) this.playerId = playerId;
+        else playerId = Guid.NewGuid().ToString();
         this.avatar = avatar;
         this.name = name;
         this.username = username;
@@ -168,8 +169,8 @@ public class Stats
     public bool needWelcome = true;
     public bool isNumberSystemUnlocked = false;
     public bool isIntroProgrammingUnlocked = false;
-    public float computerHistory;
-    public float computerElements;
-    public float numberSystem;
-    public float introProgramming;
+    public float computerHistory = 0f;
+    public float computerElements = 0f;
+    public float numberSystem = 0f;
+    public float introProgramming = 0f;
 }

--- a/Assets/Scripts/Managers/DebugManager.cs
+++ b/Assets/Scripts/Managers/DebugManager.cs
@@ -10,7 +10,7 @@ public class DebugManager : MonoBehaviour
         if (!SaveManager.player.stats.isIntroProgrammingUnlocked && topic == "ITP") cribManager.ShowMessage($"ITP is locked!");
         if (!SaveManager.player.stats.isNumberSystemUnlocked && topic == "NS") cribManager.ShowMessage($"NS is locked!");
 
-        SaveManager.player.IncreaseStat(topic, 0.10f);
+        SaveManager.player.IncreaseStat(topic, 100f);
         cribManager.UpdateButtons();
         settings.UpdatePlayerInterface();
     }

--- a/Assets/Scripts/Managers/PlayManager.cs
+++ b/Assets/Scripts/Managers/PlayManager.cs
@@ -194,7 +194,7 @@ public class PlayManager : MonoBehaviour
             answeredQuestions
         );
 
-        SaveManager.player.IncreaseStat(GetTopic(topicIndex), score / 300f);
+        SaveManager.player.IncreaseStat(GetTopic(topicIndex), score);
         questionText.text = "Quiz Over! Your score: " + score;
         settings.UpdatePlayerInterface();
         cribManager.UpdateButtons();

--- a/Assets/Scripts/Minigames/Runner/Runner.cs
+++ b/Assets/Scripts/Minigames/Runner/Runner.cs
@@ -216,7 +216,7 @@ public class Runner : Minigame
         standingsPanel.SetActive(true);
         yield return new WaitForSeconds(time);
         standingsPanel.SetActive(false);
-        SaveManager.player.IncreaseStat(topic, 0.25f / CalculateTotalScore(answeredQuestions));
+        SaveManager.player.IncreaseStat(topic, CalculateTotalScore(answeredQuestions));
         settings.UpdatePlayerInterface();
         NotifyIncrease();
     }
@@ -280,7 +280,7 @@ public class Runner : Minigame
         return attempts switch
         {
             0 => 1.0f,// 0 attempts
-            1 => 0.57f,// 1 attempt
+            1 => 0.75f,// 1 attempt
             2 => 0.50f,// 2 attempts
             3 => 0.25f,// 3 attempts
             _ => 0.0f,// More than 3 attempts

--- a/Assets/Scripts/Minigames/Territory Conquest/TerritoryConquest.cs
+++ b/Assets/Scripts/Minigames/Territory Conquest/TerritoryConquest.cs
@@ -196,7 +196,7 @@ public class TerritoryConquest : Minigame
         quizPanel.SetActive(false);
 
         // Notify increase
-        SaveManager.player.IncreaseStat(topic, score / 600f);
+        SaveManager.player.IncreaseStat(topic, score);
         NotifyIncrease();
     }
 

--- a/Assets/Scripts/Minigames/Trivia Showdown/TriviaShowdown.cs
+++ b/Assets/Scripts/Minigames/Trivia Showdown/TriviaShowdown.cs
@@ -221,7 +221,7 @@ public class TriviaShowdown : Minigame
         quizPanel.SetActive(false);
 
         // Notify Increase
-        SaveManager.player.IncreaseStat(topic, score / 600f);
+        SaveManager.player.IncreaseStat(topic, score);
         NotifyIncrease();
     }
 

--- a/Assets/Scripts/UserInterface/Settings.cs
+++ b/Assets/Scripts/UserInterface/Settings.cs
@@ -9,6 +9,11 @@ public class Settings : MonoBehaviour
     public Image[] statBars, lockImages;
     public TMP_Text[] statTexts;
 
+    private void OnEnable()
+    {
+        UpdatePlayerInterface();
+    }
+
     void Start()
     {
         UpdatePlayerInterface();
@@ -33,8 +38,8 @@ public class Settings : MonoBehaviour
 
         for (int i = 0; i < playerStats.Length; i++)
         {
-            statBars[i].fillAmount = playerStats[i];
-            statTexts[i].text = ((int)(playerStats[i] * 10000)).ToString();
+            statBars[i].fillAmount = playerStats[i] / 1000f;
+            statTexts[i].text = playerStats[i].ToString();
         }
     }
 

--- a/Docs/Minigames.md
+++ b/Docs/Minigames.md
@@ -1,143 +1,101 @@
-**Minigames Documentation**
-====================================================
+# Minigames Documentation
 
-**Abbreviations**
------------------
+---
 
-* `HOC` - History of Computing
-* `EOCS` - Elements of Computer Systems
-* `NS` - Number System
-* `ITP` - Introduction to Programming
+## Abbreviations
 
-**Commonly Shared Variables**
------------------------------
+| **Abbreviation** | **Full Form**                        |
+| ---------------- | ------------------------------------ |
+| **HOC**          | History of Computing                 |
+| **EOCS**         | Elements of Computer Systems         |
+| **NS**           | Number System                        |
+| **ITP**          | Introduction to Programming          |
 
-### correct
+---
 
-Aka "quiz points" or "score" for storing how many times the player answered correctly.
+## Commonly Shared Variables
 
-### score
+- **`correct`**: Stores how many times the player answered correctly.
+- **`score`**: Varies depending on the minigame's gameplay.
+- **`total`**: Total number of questions that will show, which varies depending on gameplay length.
+- **`topic points`**: The currently selected topic, which increases the player's stats (topic) at the end of the minigame.
 
-Aka "game points" minigame specific, varies depending to the minigame's gameplay.
+---
 
-### total
+## Minigames
 
-Total questions that will show, also minigame specific varies depending to gameplay length.
+### 1. Runner
 
-### topic points
+- **total**: Set to **10**.
 
-The currently selected topic which will increases the player stat (topic) at the end of the minigame.
+#### Gameplay Scoring
 
-**Runner**
-----------
+##### Logic
 
-### Values
+- **Correct Answer**: Increases `score` by **100** for answering correctly.
+- **Wrong Answer**: Decreases `score` by **20** for answering incorrectly.
 
-#### total
+##### Additional Points
 
-Currently set to 10.
+Awarded when reaching the finish line:
 
-### Scoring
--------------
+| **Position** | **Points** |
+| ------------ | ---------- |
+| 1st          | 100        |
+| 2nd          | 75         |
+| 3rd          | 50         |
+| 4th          | 25         |
 
-### Gameplay Scoring
+---
 
-#### Correct Answer
+#### Stat Scoring
 
-Increases `score` by 100 for answering correctly.
+##### Computation
 
-#### Wrong Answer
+| **Attempts**       | **Points Awarded** |
+| ------------------ | ------------------ |
+| 0 attempts         | 1 point            |
+| 1 attempt          | 0.75 points        |
+| 2 attempts         | 0.50 points        |
+| 3 attempts         | 0.25 points        |
+| More than 3 attempts | 0 points          |
 
-Decreases `score` by 20 for answering incorrectly.
+##### Note
 
-#### Additional Points
+- **Max Score**: The maximum score a player can gain is **10 topic points** (excluding additional points).
+- **Stat Increase**: At the end, the stat increase is based on the player's `topic points`.
 
-Gives additional points when reached the finish line:
+---
 
-* 100 points for 1st.
-* 75 points for 2nd.
-* 50 points for 3rd.
-* 25 points for 4th.
+### 2. Trivia Showdown
 
-### Stat Scoring
-----------------
+- **total**: Set to **15**.
 
-#### Computation
+#### Gameplay Scoring
 
-Computes the score per item depending on the answer attempt and will be totaled at the end of the minigame:
+- **Correct Answer**: Increases both `score` and `correct` by 1.
+- **Max Score**: The maximum score a player can gain is **15 quiz points**.
+- **Stat Increase**: At the end, stat increase is based on the player's `topic points`.
 
-* 0 attempts give 1 points.
-* 1 attempt gives 0.75 points.
-* 2 attempts give 0.50 points.
-* 3 attempts give 0.25 points.
-* More than 3 attempts give 0 points.
+---
 
-#### Max Score
+### 3. Territory Conquest
 
-Max score can a player can gain is `10 quiz points` or `0.025 topic points`.
+- **total**: Depends on how many tiles the player interacted with, computed at the end of the minigame.
+- **Correct Answer**: Increases `correct` by 1, then occupies the tile.
+- **Wrong Answer**: Only records the answer attempt.
+- **Tile Update**: If another player answers correctly, the player's score is decreased by 1, and the other player's score is increased by 1, updating the tile's ownership.
+- **Stat Increase**: At the end, computation for stat increase will base on the player's topic points.
 
-#### Stat Increase
+---
 
-At the end - computation for stat increase `(0.25 / quiz points)`.
+## Unlocking New Topics
 
-**Trivia Showdown**
--------------------
+| **Topic**   | **Requirement**                    |
+| ----------- | ---------------------------------- |
+| **NS**      | Requires `100 HOC topic points`    |
+| **ITP**     | Requires `150 EOCS topic points`   |
 
-### Variables
--------------
+- The score ceiling will depends on the `total` of each minigame.
+---
 
-#### total
-
-Currently set to 15.
-
-### Scoring
--------------
-
-#### Correct Answer
-
-Increases both `score` and `correct` by 1.
-
-#### Max Score
-
-Max score can a player can gain is `15 quiz points` or `0.025 topic points`.
-
-#### Stat Increase
-
-At the end - computation for stat increase `(quiz points / 600f)`.
-
-**Territory Conquest**
-----------------------
-
-### Values
-------------
-
-#### total
-
-Depends how many tiles the player interacted with, computes at the end of the minigame.
-
-### Scoring
--------------
-
-#### Correct Answer
-
-Increases `correct` by 1 then occupies the tile.
-
-#### Wrong Answer
-
-Only records the answer attempt.
-
-#### Tile Update
-
-When other player answers correctly the player occupied tile it decrease the player's score by 1 and other player's score by 1 and updates the tile.
-
-#### Stat Increase
-
-At the end - computation for stat increase `(correct / 600f)`.
-
-**Notes**
--------
-
-* To unlock NS, it needs `0.2 HOC topic points`.
-* To unlock ITP, it needs `0.3 EOCS topic points`.
-* Standard `topic points` ceiling is `0.025`.
-	+ If the player continuously gains `0.025 topic points` per minigame it will require 8 games to unlock NS and 12 games for ITP.


### PR DESCRIPTION
Updated the stats to start as whole number.
Balanced unlock conditions as the scoring system updates.
Changed score computation for the single player quiz.

BREAKING CHANGE: The save files created before the update may misbehave. Developers may clear the stats from the save file to work properly.

Closes #11, resolves #12, fixes #13